### PR TITLE
Better deploy script

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,25 +1,45 @@
-name: Build and Deploy
+name: Build and deploy website
+
 on:
     push:
-        branches:
-            - main
+        branches: [main]
+    workflow_dispatch:
+
 permissions:
-    contents: write
+    contents: read
+    pages: write
+    id-token: write
+
+concurrency:
+    group: "pages"
+    cancel-in-progress: false
+
 jobs:
     build-and-deploy:
-        concurrency: ci-${{ github.ref }} # Recommended if you intend to make multiple deployments in quick succession.
+        environment:
+            name: github-pages
+            url: ${{ steps.deployment.outputs.url }}
         runs-on: ubuntu-latest
         steps:
-            - name: Checkout 🛎️
+            - name: Checkout code
               uses: actions/checkout@v4
 
-            - name: Install and Build
+            - name: Setup Pages
+              uses: actions/configure-pages@v3
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v4
+
+            - name: Build the website
               run: |
-                  npm ci
+                  npm install
                   npm run build
 
-            - name: Deploy
-              uses: JamesIves/github-pages-deploy-action@v4
+            - name: Upload artifact
+              uses: actions/upload-pages-artifact@v2
               with:
-                  branch: gh-pages # The branch the action should deploy to.
-                  folder: build # The folder the action should deploy.
+                  path: ./build
+
+            - name: Deploy to GitHub Pages
+              id: deployment
+              uses: actions/deploy-pages@v2


### PR DESCRIPTION
It's about 2 times faster (because it uses 1 job and not 4) and you don't need `gh-pages` branch anymore.
